### PR TITLE
bump jenkins baseline version from 2.249 to 2.263

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,20 +9,20 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>muuri-api</artifactId>
-    <version>0.9.4-3-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <name>Muuri.js API plugin</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <packaging>hpi</packaging>
     <description>Jenkins plug-in that provides Muuri.js (https://muuri.dev).</description>
 
     <properties>
-        <revision>0.9.3-3</revision>
+        <revision>0.9.5-1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.baseline>2.249</jenkins.baseline>
+        <jenkins.baseline>2.263</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <muuri.version>0.9.3</muuri.version>
+        <muuri.version>0.9.5</muuri.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
Bump jenkins baseline version from 2.249 to 2.263.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
